### PR TITLE
setup project to support secure configuration files

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+## Why is this change necessary?
+*
+
+## How does it address the issue?
+*
+
+## What potential side effects does this change have?
+*

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,11 @@
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
 
+## Configuration files
+Debug.xcconfig
+Release.xcconfig
+BoosterKit.xcconfig
+
 ## Build generated
 build/
 DerivedData/

--- a/BoosterKit.xcodeproj/project.pbxproj
+++ b/BoosterKit.xcodeproj/project.pbxproj
@@ -15,6 +15,11 @@
 		CE1ECBBD1E5244CF00F4A7C9 /* PhotosViewControllerFeatures.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1ECBBA1E5244CF00F4A7C9 /* PhotosViewControllerFeatures.swift */; };
 		CE1ECBBE1E5244CF00F4A7C9 /* XCTestCaseExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1ECBBB1E5244CF00F4A7C9 /* XCTestCaseExtension.swift */; };
 		CE2E4B681DD614A5007A86E6 /* XCTestCaseExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2E4B671DD614A5007A86E6 /* XCTestCaseExtension.swift */; };
+		CE529BAD1E892A57007FCED6 /* check_config_files.rb in Resources */ = {isa = PBXBuildFile; fileRef = CE529BA91E892A57007FCED6 /* check_config_files.rb */; };
+		CE529BAE1E892A57007FCED6 /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = CE529BAA1E892A57007FCED6 /* Debug.xcconfig */; };
+		CE529BAF1E892A57007FCED6 /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = CE529BAB1E892A57007FCED6 /* Release.xcconfig */; };
+		CE529BB21E892A9A007FCED6 /* BoosterKit.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = CE529BB11E892A9A007FCED6 /* BoosterKit.xcconfig */; };
+		CE529BB41E893008007FCED6 /* buddybuild_prebuild.sh in Resources */ = {isa = PBXBuildFile; fileRef = CE529BB31E893008007FCED6 /* buddybuild_prebuild.sh */; };
 		CEB08BDD1E044D740088E2D0 /* PhotoDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB08BDB1E044D740088E2D0 /* PhotoDetailViewController.swift */; };
 		CEB08BDE1E044D740088E2D0 /* PhotosViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB08BDC1E044D740088E2D0 /* PhotosViewController.swift */; };
 		CEB08BE11E044D840088E2D0 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CEB08BDF1E044D840088E2D0 /* LaunchScreen.storyboard */; };
@@ -63,6 +68,11 @@
 		CE1ECBBB1E5244CF00F4A7C9 /* XCTestCaseExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestCaseExtension.swift; sourceTree = "<group>"; };
 		CE2E4B671DD614A5007A86E6 /* XCTestCaseExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestCaseExtension.swift; sourceTree = "<group>"; };
 		CE2E4B691DD62BBC007A86E6 /* BoosterKit-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BoosterKit-Bridging-Header.h"; sourceTree = "<group>"; };
+		CE529BA91E892A57007FCED6 /* check_config_files.rb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.ruby; name = check_config_files.rb; path = Config/check_config_files.rb; sourceTree = "<group>"; };
+		CE529BAA1E892A57007FCED6 /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Config/Debug.xcconfig; sourceTree = "<group>"; };
+		CE529BAB1E892A57007FCED6 /* Release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Config/Release.xcconfig; sourceTree = "<group>"; };
+		CE529BB11E892A9A007FCED6 /* BoosterKit.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = BoosterKit.xcconfig; path = Config/BoosterKit.xcconfig; sourceTree = "<group>"; };
+		CE529BB31E893008007FCED6 /* buddybuild_prebuild.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = buddybuild_prebuild.sh; sourceTree = "<group>"; };
 		CEB08BDB1E044D740088E2D0 /* PhotoDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PhotoDetailViewController.swift; path = Views/Controllers/PhotoDetailViewController.swift; sourceTree = "<group>"; };
 		CEB08BDC1E044D740088E2D0 /* PhotosViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PhotosViewController.swift; path = Views/Controllers/PhotosViewController.swift; sourceTree = "<group>"; };
 		CEB08BDF1E044D840088E2D0 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = Views/Storyboards/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -138,6 +148,17 @@
 			path = BoosterKitFeatures;
 			sourceTree = "<group>";
 		};
+		CE529BA81E892A45007FCED6 /* Config */ = {
+			isa = PBXGroup;
+			children = (
+				CE529BA91E892A57007FCED6 /* check_config_files.rb */,
+				CE529BB11E892A9A007FCED6 /* BoosterKit.xcconfig */,
+				CE529BAA1E892A57007FCED6 /* Debug.xcconfig */,
+				CE529BAB1E892A57007FCED6 /* Release.xcconfig */,
+			);
+			name = Config;
+			sourceTree = "<group>";
+		};
 		CEB08BD81E044C090088E2D0 /* Views */ = {
 			isa = PBXGroup;
 			children = (
@@ -182,6 +203,7 @@
 				CECCBFF41DBA8FE600789698 /* Products */,
 				D6EA0DCB1C2B5FA7B5ADB51F /* Pods */,
 				C9E9E29A624DEA86E96E52ED /* Frameworks */,
+				CE529BB31E893008007FCED6 /* buddybuild_prebuild.sh */,
 			);
 			sourceTree = "<group>";
 		};
@@ -198,6 +220,7 @@
 		CECCBFF51DBA8FE600789698 /* BoosterKit */ = {
 			isa = PBXGroup;
 			children = (
+				CE529BA81E892A45007FCED6 /* Config */,
 				CEB08BE31E04504C0088E2D0 /* Library */,
 				CE1BE42F1DBA993700DD6C44 /* Models */,
 				CEB08BD81E044C090088E2D0 /* Views */,
@@ -361,8 +384,13 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CE529BB21E892A9A007FCED6 /* BoosterKit.xcconfig in Resources */,
 				CEB08BE21E044D840088E2D0 /* Main.storyboard in Resources */,
+				CE529BAD1E892A57007FCED6 /* check_config_files.rb in Resources */,
+				CE529BAE1E892A57007FCED6 /* Debug.xcconfig in Resources */,
 				CECCBFFE1DBA8FE600789698 /* Assets.xcassets in Resources */,
+				CE529BB41E893008007FCED6 /* buddybuild_prebuild.sh in Resources */,
+				CE529BAF1E892A57007FCED6 /* Release.xcconfig in Resources */,
 				CEB08BE11E044D840088E2D0 /* LaunchScreen.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -601,6 +629,7 @@
 		};
 		CECCC0191DBA8FE700789698 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = CE529BB11E892A9A007FCED6 /* BoosterKit.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -652,6 +681,7 @@
 		};
 		CECCC01A1DBA8FE700789698 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = CE529BB11E892A9A007FCED6 /* BoosterKit.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -696,7 +726,7 @@
 		};
 		CECCC01C1DBA8FE700789698 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BD1E0882EC486B09220281C0 /* Pods-BoosterKit.debug.xcconfig */;
+			baseConfigurationReference = CE529BAA1E892A57007FCED6 /* Debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -714,7 +744,7 @@
 		};
 		CECCC01D1DBA8FE700789698 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C11E36F72A29AB21CABDF6D2 /* Pods-BoosterKit.release.xcconfig */;
+			baseConfigurationReference = CE529BAB1E892A57007FCED6 /* Release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;

--- a/BoosterKit/AppDelegate.swift
+++ b/BoosterKit/AppDelegate.swift
@@ -20,6 +20,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         BuddyBuildSDK.setup()
         
         NSLog("Realm DB: \(Realm.Configuration.defaultConfiguration.fileURL)")
+        NSLog("DarkSkyAPIKey: \(Bundle.main.infoDictionary?["DarkSkyAPIKey"] as! String)")
         
         return true
     }

--- a/BoosterKit/Config/BoosterKit.example.xcconfig
+++ b/BoosterKit/Config/BoosterKit.example.xcconfig
@@ -1,0 +1,7 @@
+//
+//  BoosterKit.xcconfig
+//  BoosterKit
+//
+//  Created by Travis Palmer on 2/23/17.
+//  Copyright © 2017 Spartan. All rights reserved.
+//

--- a/BoosterKit/Config/Debug.example.xcconfig
+++ b/BoosterKit/Config/Debug.example.xcconfig
@@ -1,0 +1,18 @@
+//
+//  Debug.xcconfig
+//  BoosterKit
+//
+//  Created by Travis Palmer on 2/23/17.
+//  Copyright © 2017 Spartan. All rights reserved.
+//
+
+#include "Pods/Target Support Files/Pods-BoosterKit/Pods-BoosterKit.debug.xcconfig"
+
+// Add a value to Info.plist similar to the following:
+// DarkSkyAPIKey, String, $(DARK_SKY_API_KEY)
+//
+// Access the value programmatically like so:
+// Bundle.main.infoDictionary?["DarkSkyAPIKey"]
+//
+// Uncomment the line below.
+//DARK_SKY_API_KEY = 1234

--- a/BoosterKit/Config/Release.example.xcconfig
+++ b/BoosterKit/Config/Release.example.xcconfig
@@ -1,0 +1,18 @@
+//
+//  Release.xcconfig
+//  BoosterKit
+//
+//  Created by Travis Palmer on 2/23/17.
+//  Copyright © 2017 Spartan. All rights reserved.
+//
+
+#include "Pods/Target Support Files/Pods-BoosterKit/Pods-BoosterKit.release.xcconfig"
+
+// Add a value to Info.plist similar to the following:
+// DarkSkyAPIKey, String, $(DARK_SKY_API_KEY)
+//
+// Access the value programmatically like so:
+// Bundle.main.infoDictionary?["DarkSkyAPIKey"]
+//
+// Uncomment the line below.
+//DARK_SKY_API_KEY = 5678

--- a/BoosterKit/Config/check_config_files.rb
+++ b/BoosterKit/Config/check_config_files.rb
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+
+require 'fileutils'
+
+# Create default xcconfig files if they're not present.
+source_path = 'BoosterKit/Config/CONFIGURATION.example.xcconfig'
+destination_path = 'BoosterKit/Config/CONFIGURATION.xcconfig'
+
+['Debug', 'Release', 'BoosterKit'].each do |config|
+  source_file = source_path.gsub(/CONFIGURATION/, config)
+  destination_file = destination_path.gsub(/CONFIGURATION/, config)
+
+  if !File.file?(destination_file)
+    FileUtils.copy source_file, destination_file
+  end
+end

--- a/BoosterKit/Info.plist
+++ b/BoosterKit/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>DarkSkyAPIKey</key>
+	<string>$(DARK_SKY_API_KEY)</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSExceptionDomains</key>

--- a/buddybuild_prebuild.sh
+++ b/buddybuild_prebuild.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+ruby BoosterKit/Config/check_config_files.rb


### PR DESCRIPTION
## Why is this change necessary?
* https://github.com/spartansystems/booster-kit-swift/issues/3
* https://github.com/spartansystems/booster-kit-swift/issues/5

## How does it address the issue?
* It adds example configuration files to the repository for each build configuration (Debug, Release), as well as project-level configuration (BoosterKit).  These should be copied/renamed locally per-environment, and serve as a place to store values we don't want in source control.
* It configures the Xcode project to use a value in Info.plist that pulls from the project files.
* It updates .gitignore so we're not accidentally committing local files.
* It provides some examples of how to access values programmatically.
* It adds some scripts so that everything compiles correctly in a BuddyBuild VM.

## What potential side effects does this change have?
* None